### PR TITLE
🐛(project) fix typo in Makefile bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ git-clean: ## restore repository state as it was freshly cloned
 # -- Project
 bootstrap: ## Bootstrap project
 bootstrap: \
-	gitmodules-init \
+	git-modules-init \
 	run
 .PHONY: bootstrap
 


### PR DESCRIPTION
## Purpose

fix typo in Makefile bootstrap target that breaks `make bootstrap`

## Proposal

- [x] Correct git-modules-init that was misspelled
